### PR TITLE
chore: skip tag description in tag bump script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -6,5 +6,5 @@ LATEST_SHA=$(git rev-parse master)
 NEW_TAG=$(semver -c -i "$RELEASE_TYPE" "$LATEST_TAG")
 
 # echo $LATEST_TAG "v$NEW_TAG" $LATEST_SHA
-git tag "v$NEW_TAG" "$LATEST_SHA"
+git tag -m "" "v$NEW_TAG" "$LATEST_SHA"
 git push origin "v$NEW_TAG"


### PR DESCRIPTION
It's no needed with release auto notes.
